### PR TITLE
gzip labslink files prior to upload

### DIFF
--- a/buildfiles/generateUploadLabsLink.sh
+++ b/buildfiles/generateUploadLabsLink.sh
@@ -11,6 +11,7 @@ fi
 JAVA_BIN=/usr/bin/java
 CURL_BIN=/usr/bin/curl
 XMLLINT_BIN=/usr/bin/xmllint
+GZIP_BIN=/bin/gzip
 
 LABSLINK_FTP_PASSWORD_FILE=$1
 LABSLINK_TOOL_DIR=`dirname $0`
@@ -45,7 +46,8 @@ done
 # 3. Upload the labslink files
 for LABSLINK_FILE in $OUTPUT_DIR/*
 do
-	$CURL_BIN "$LABSLINK_FTP" -T "$LABSLINK_FILE" -K "$LABSLINK_FTP_PASSWORD_FILE" 2> "$LABSLINK_ERROR_FILE"
+	$GZIP_BIN "$LABSLINK_FILE"
+	$CURL_BIN "$LABSLINK_FTP" -T "${LABSLINK_FILE}.gz" -K "$LABSLINK_FTP_PASSWORD_FILE" 2> "$LABSLINK_ERROR_FILE"
 done
 
 # Cleanup, remove generated files


### PR DESCRIPTION
Fixes file size issue reported by Europe PMC:

> Dear Dryad Digital Repository,
>  
> The links file that you update every Sunday: "labslink-links.xml" (for the Europe PMC External Links Service), has just gone over the 2MB-per-file limit, and therefore cannot be processed. You need to either start compressing the file before uploading, or begin writing to a second links file.
> 
> Files must be no bigger than 2 MB each. The total file size limit is 500 MB. All files must be named with one of the following extensions:
>  
> .xml
> .zip
> .gz
> .tar
> .tar.gz
> .targz
