### PR TITLE
Retain output files between runs

### DIFF
--- a/buildfiles/generateUploadLabsLink.sh
+++ b/buildfiles/generateUploadLabsLink.sh
@@ -26,6 +26,10 @@ LABSLINK_ERROR_FILE="/tmp/labslink.error"
 # Trap any error output and mail it
 trap 'mail -s "Error running `basename $0` on line $LINENO; rc=$?" "$LABSLINK_ERROR_EMAIL" < "$LABSLINK_ERROR_FILE" >/dev/null' ERR
 
+# Cleanup, remove any old generated files
+
+rm -rf "$OUTPUT_DIR" 2> "$LABSLINK_ERROR_FILE"
+
 # 0. Make the output dir if it does not yet exist
 cd "$LABSLINK_TOOL_DIR"
 if [ ! -d "$OUTPUT_DIR" ]; then
@@ -50,6 +54,3 @@ do
 	$CURL_BIN "$LABSLINK_FTP" -T "${LABSLINK_FILE}.gz" -K "$LABSLINK_FTP_PASSWORD_FILE" 2> "$LABSLINK_ERROR_FILE"
 done
 
-# Cleanup, remove generated files
-
-rm -rf "$OUTPUT_DIR" 2> "$LABSLINK_ERROR_FILE"

--- a/buildfiles/generateUploadLinkout.sh
+++ b/buildfiles/generateUploadLinkout.sh
@@ -25,6 +25,10 @@ LINKOUT_ERROR_FILE="/tmp/linkout.error"
 # Trap any error output and mail it
 trap 'mail -s "Error running `basename $0` on line $LINENO; rc=$?" "$LINKOUT_ERROR_EMAIL" < "$LINKOUT_ERROR_FILE" >/dev/null' ERR
 
+# Cleanup, remove old generated files
+
+rm -rf "$OUTPUT_DIR" 2> "$LINKOUT_ERROR_FILE"
+
 # 0. Make the output dir if it does not yet exist
 cd "$LINKOUT_TOOL_DIR"
 if [ ! -d "$OUTPUT_DIR" ]; then
@@ -48,6 +52,4 @@ do
 	$CURL_BIN "$LINKOUT_FTP" -T "$LINKOUT_FILE" -K "$LINKOUT_FTP_PASSWORD_FILE" 2> "$LINKOUT_ERROR_FILE"
 done
 
-# Cleanup, remove generated files
 
-rm -rf "$OUTPUT_DIR" 2> "$LINKOUT_ERROR_FILE"


### PR DESCRIPTION
Previously, these scripts would clean up output files as soon as the
scripts were done running. This made it impossible to review the
output files and troubleshoot in response to queries from NCBI.

This commit cleans up output files at the beginning of the process,
allowing output to remain in place between subsequent runs of the
scripts.