### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/src/main/org/datadryad/interop/DryadPackage.java
+++ b/src/main/org/datadryad/interop/DryadPackage.java
@@ -44,9 +44,9 @@ public class DryadPackage {
     final static String PMIDQUERYURI = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term=";
     final static String PMIDQUERYSUFFIX = "[doi]"; 
     final static String DRYADDOIPREFIX = "doi:10.5061/dryad";
-    final static String DRYADHTTPPREFIX = "http://dx.doi.org/10.5061/dryad";
+    final static String DRYADHTTPPREFIX = "https://doi.org/10.5061/dryad";
     final static String DOIPREFIX = "doi:";
-    final static String HTTPDOIPREFIX = "http://dx.doi.org/";
+    final static String HTTPDOIPREFIX = "https://doi.org/";
 
     
     int itemid;

--- a/src/main/org/datadryad/interop/LabsLinkLinksTarget.java
+++ b/src/main/org/datadryad/interop/LabsLinkLinksTarget.java
@@ -19,7 +19,7 @@ import nu.xom.Serializer;
  * @author dan.leehr@nescent.org
  */
 public class LabsLinkLinksTarget {
-    private static final String BASE_URL = "http://dx.doi.org/";
+    private static final String BASE_URL = "https://doi.org/";
     private static final String DRYAD_PROVIDER_ID = "1012";
     private static final String PUBMED_RECORD_SOURCE = "MED";
 


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

Here, I'd like to suggest to update all code that generates new DOI links.

Cheers!